### PR TITLE
Remove schema reference from manifest

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json",
   ".": "0.1.0"
 }


### PR DESCRIPTION
Deleted the $schema property from .release-please-manifest.json to simplify the manifest structure.